### PR TITLE
Don't ask for confirmation when saving with a bang

### DIFF
--- a/plugin/auto_mkdir2.vim
+++ b/plugin/auto_mkdir2.vim
@@ -27,7 +27,7 @@ command! -nargs=* -complete=dir MkdirP call s:mkdir_p(<q-args>, 1)
 
 augroup auto_mkdir2
 	autocmd!
-	autocmd BufWritePre * call s:mkdir_p(expand("<amatch>:p:h"), 0)
+	autocmd BufWritePre * call s:mkdir_p(expand("<amatch>:p:h"), v:cmdbang)
 augroup end
 
 


### PR DESCRIPTION
Simply makes it so when writing `w!` it does not ask if you want to save. 

Works with any saving command that could have a bang in it.