### PR TITLE
Allow turning on directory creation selectively instead of everywhere

### DIFF
--- a/doc/auto_mkdir2.txt
+++ b/doc/auto_mkdir2.txt
@@ -22,6 +22,11 @@ OPTIONS                                                  *auto_mkdir2_options*
 
         Ask for confirmation before automatically creating a directory.
 
+*g:auto_mkdir2_allfiles*                (Boolean, default: 1)
+
+        Setting |g:auto_mkdir2_allfiles| to 0 disables automatic directory
+        creation. See |MkdirPC|.
+
 ==============================================================================
 COMMANDS                                                *auto_mkdir2_commands*
 
@@ -33,6 +38,24 @@ directory.
 
 The [directory] is |expand()|-ed. The parameter is optional and [%:h:p] is
 used if it is empty.
+
+MkdirPC [directory]                                                  *:MkdirPC*
+
+Functions identically to MkdirP except that appending a '!' will force the
+creation, regardless of the value of |g:auto_mkdir2_confirm|.
+
+This command is most useful if |g:auto_mkdir2_allfiles| == '0' as MkdirPC can
+then be used in autocmds to turn on automatic directory creation for certain
+files.
+
+The following turns on automatic directory creation only for files with an
+*.md extension: 
+
+let |g:auto_mkdir2_allfiles| = 0
+augroup auto_mkdir2
+    autocmd!
+	autocmd BufWritePre *.md |MkdirPC|
+augroup end
 
 
 vim:tw=78:ts=8:ft=help:norl:expandtab

--- a/doc/tags
+++ b/doc/tags
@@ -1,5 +1,7 @@
 :MkdirP	auto_mkdir2.txt	/*:MkdirP*
+:MkdirPC	auto_mkdir2.txt	/*:MkdirPC*
 auto_mkdir2	auto_mkdir2.txt	/*auto_mkdir2*
 auto_mkdir2_commands	auto_mkdir2.txt	/*auto_mkdir2_commands*
 auto_mkdir2_options	auto_mkdir2.txt	/*auto_mkdir2_options*
+g:auto_mkdir2_allfiles	auto_mkdir2.txt	/*g:auto_mkdir2_allfiles*
 g:auto_mkdir2_confirm	auto_mkdir2.txt	/*g:auto_mkdir2_confirm*

--- a/plugin/auto_mkdir2.vim
+++ b/plugin/auto_mkdir2.vim
@@ -16,6 +16,9 @@ set cpo&vim
 
 "##########################################################
 " Options
+if !exists('g:auto_mkdir2_allfiles')
+    let g:auto_mkdir2_allfiles = 1
+endif
 if !exists('g:auto_mkdir2_confirm')
 	let g:auto_mkdir2_confirm = 1
 endif
@@ -24,11 +27,14 @@ endif
 "##########################################################
 " Commands
 command! -nargs=* -complete=dir MkdirP call s:mkdir_p(<q-args>, 1)
+command! -nargs=* -complete=dir MkdirPC call s:mkdir_p(<q-args>, v:cmdbang)
 
-augroup auto_mkdir2
-	autocmd!
-	autocmd BufWritePre * call s:mkdir_p(expand("<amatch>:p:h"), v:cmdbang)
-augroup end
+if g:auto_mkdir2_allfiles == "1"
+    augroup auto_mkdir2
+        autocmd!
+        autocmd BufWritePre * call s:mkdir_p(expand("<amatch>:p:h"), v:cmdbang)
+    augroup end
+endif
 
 
 "##########################################################


### PR DESCRIPTION
As designed the plugin is active for all files but I wanted to be able to turn it on only for certain files. Out of the box the plugin works exactly like it did before, but I added one variable (**g:auto_mkdir2_allfiles**) and one command (**MkdirPC**).

Setting **g:auto_mkdir2_allfiles = 1** turns off the **augroup** in the plugin. You can then create your own **augroup** or binding that uses **MkdirPC** (which supports a **!** to force creation)

