### PR TITLE
Add g:auto_mkdir2_autocmd; move functions to autoload 

### DIFF
--- a/autoload/auto_mkdir2.vim
+++ b/autoload/auto_mkdir2.vim
@@ -1,0 +1,35 @@
+" Create the directory path. This will also create any intermediate
+" directories.
+"
+" If confirm is non-0 it will ask for confirmation first.
+fun! auto_mkdir2#mkdir_p(path, confirm) abort
+	let l:dir = expand(a:path)
+	if l:dir is# ''
+		let l:dir = expand('%:p:h')
+	endif
+
+	if isdirectory(l:dir)
+		return
+	endif
+
+	if filereadable(l:dir)
+		echohl Error | echom printf("%s exists and isn't a directory", l:dir) | echohl None
+		return
+	endif
+
+	let l:response = 'y'
+	if a:confirm
+		echohl Question | echon printf('Create directory "%s" [y/N]? ', a:path) | echohl None
+
+		" TODO: When using :wq or ZZ I need to press <CR> here after y?
+		let response = nr2char(getchar())
+	endif
+
+    if l:response is? 'y'
+		call mkdir(iconv(l:dir, &encoding, &termencoding), 'p')
+    endif
+endfun
+
+fun! auto_mkdir2#autocmd() abort
+	return auto_mkdir2#mkdir_p(expand('<amatch>:p:h'), !v:cmdbang && get(g:, 'auto_mkdir2_confirm', 1))
+endfun

--- a/doc/auto_mkdir2.txt
+++ b/doc/auto_mkdir2.txt
@@ -22,6 +22,11 @@ OPTIONS                                                  *auto_mkdir2_options*
 
         Ask for confirmation before automatically creating a directory.
 
+*g:auto_mkdir2_allfiles*                (Boolean, default: 1)
+
+        Setting |g:auto_mkdir2_allfiles| to 0 disables automatic directory
+        creation. See |MkdirPC|.
+
 ==============================================================================
 COMMANDS                                                *auto_mkdir2_commands*
 
@@ -33,6 +38,24 @@ directory.
 
 The [directory] is |expand()|-ed. The parameter is optional and [%:h:p] is
 used if it is empty.
+
+MkdirPC [directory]                                                  *:MkdirPC*
+
+Functions identically to MkdirP except that appending a '!' will force the
+creation, regardless of the value of |g:auto_mkdir2_confirm|.
+
+This command is most useful if |g:auto_mkdir2_allfiles| == '0' as MkdirPC can
+then be used in autocmds to turn on automatic directory creation for certain
+files.
+
+The following turns on automatic directory creation only for files with an
+*.md extension: 
+
+let |g:auto_mkdir2_allfiles| = 0
+augroup auto_mkdir2
+    autocmd!
+	autocmd BufWritePre *.md |MkdirPC|
+augroup end
 
 
 vim:tw=78:ts=8:ft=help:norl:expandtab

--- a/doc/auto_mkdir2.txt
+++ b/doc/auto_mkdir2.txt
@@ -16,46 +16,60 @@ developed independently. This version has the option to confirm directory
 creation and includes a bugfix for unicode directory names.
 
 ==============================================================================
-OPTIONS                                                  *auto_mkdir2_options*
+FUNCTIONS                                              *auto_mkdir2_functions*
 
-*g:auto_mkdir2_confirm*                 (Boolean, default: 1)
+*auto_mkdir2#mkdir_p* (path, confirm)
 
-        Ask for confirmation before automatically creating a directory.
+        Create the directory [path], and ask for confirmation if [confirm] is
+        not `0`.
 
-*g:auto_mkdir2_allfiles*                (Boolean, default: 1)
+*auto_mkdir2#autocmd* ()
 
-        Setting |g:auto_mkdir2_allfiles| to 0 disables automatic directory
-        creation. See |MkdirPC|.
+        Convenience function for calling `auto_mkdir2#mkdir_p()` from an
+        autocmd.
+
+==============================================================================
+AUTOCMD                                                  *auto_mkdir2_autocmd*
+
+By default this plugin will hook in to a |BufWritePre| |autocmd| to create
+directories that don't exist yet when writing a file.
+
+                                                       *g:auto_mkdir2_autocmd*
+You can use the `g:auto_mkdir2_autocmd` to limit to a more specific set of
+files, for example:
+
+        *.md            Only apply to Markdown files
+        *.md,*.txt      Apply to Markdown and text files
+        /some/dir/*     Only apply to files in /some/dir
+        /dir/*,*.md     Only apply to files in /dir and all Markdown files
+
+Use an empty string to not add any autocmd; you can add your own autocmds
+with: >
+
+        augroup auto_mkdir2
+                au!
+		au BufWritePre * call auto_mkdir2#autocmd()
+        augroup end
+<
+NOTE: changing this setting at runtime doesn't do anything; you'll have to set
+it at startup (i.e. in your vimrc).
 
 ==============================================================================
 COMMANDS                                                *auto_mkdir2_commands*
 
-MkdirP [directory]                                                   *:MkdirP*
+MkdirP[!] [directory]                                                *:MkdirP*
 
-Like `mkdir -p` from the shell: it will create all intermediate directories
-and will not show an error if the [directory] already exists and is a
-directory.
+        Like `mkdir -p` from the shell: it will create all intermediate
+        directories and will not show an error if the [directory] already
+        exists and is a directory.
 
-The [directory] is |expand()|-ed. The parameter is optional and [%:h:p] is
-used if it is empty.
+        The [directory] is |expand()|-ed. The parameter is optional and
+        `%:h:p` is used if it is empty.
 
-MkdirPC [directory]                                                  *:MkdirPC*
-
-Functions identically to MkdirP except that appending a '!' will force the
-creation, regardless of the value of |g:auto_mkdir2_confirm|.
-
-This command is most useful if |g:auto_mkdir2_allfiles| == '0' as MkdirPC can
-then be used in autocmds to turn on automatic directory creation for certain
-files.
-
-The following turns on automatic directory creation only for files with an
-*.md extension: 
-
-let |g:auto_mkdir2_allfiles| = 0
-augroup auto_mkdir2
-    autocmd!
-	autocmd BufWritePre *.md |MkdirPC|
-augroup end
+                                                        *g:auto_mkdir2_confirm*
+        It will ask for confirmation if `g:auto_mkdir2_confirm` is set
+        (default: 1), and adding `!` will invert the value (so if this is set
+        to `0` then it will ask for confirmation with `!`).
 
 
 vim:tw=78:ts=8:ft=help:norl:expandtab

--- a/doc/tags
+++ b/doc/tags
@@ -1,5 +1,7 @@
 :MkdirP	auto_mkdir2.txt	/*:MkdirP*
+:MkdirPC	auto_mkdir2.txt	/*:MkdirPC*
 auto_mkdir2	auto_mkdir2.txt	/*auto_mkdir2*
 auto_mkdir2_commands	auto_mkdir2.txt	/*auto_mkdir2_commands*
 auto_mkdir2_options	auto_mkdir2.txt	/*auto_mkdir2_options*
+g:auto_mkdir2_allfiles	auto_mkdir2.txt	/*g:auto_mkdir2_allfiles*
 g:auto_mkdir2_confirm	auto_mkdir2.txt	/*g:auto_mkdir2_confirm*

--- a/doc/tags
+++ b/doc/tags
@@ -1,7 +1,9 @@
 :MkdirP	auto_mkdir2.txt	/*:MkdirP*
-:MkdirPC	auto_mkdir2.txt	/*:MkdirPC*
 auto_mkdir2	auto_mkdir2.txt	/*auto_mkdir2*
+auto_mkdir2#autocmd	auto_mkdir2.txt	/*auto_mkdir2#autocmd*
+auto_mkdir2#mkdir_p	auto_mkdir2.txt	/*auto_mkdir2#mkdir_p*
+auto_mkdir2_autocmd	auto_mkdir2.txt	/*auto_mkdir2_autocmd*
 auto_mkdir2_commands	auto_mkdir2.txt	/*auto_mkdir2_commands*
-auto_mkdir2_options	auto_mkdir2.txt	/*auto_mkdir2_options*
-g:auto_mkdir2_allfiles	auto_mkdir2.txt	/*g:auto_mkdir2_allfiles*
+auto_mkdir2_functions	auto_mkdir2.txt	/*auto_mkdir2_functions*
+g:auto_mkdir2_autocmd	auto_mkdir2.txt	/*g:auto_mkdir2_autocmd*
 g:auto_mkdir2_confirm	auto_mkdir2.txt	/*g:auto_mkdir2_confirm*

--- a/plugin/auto_mkdir2.vim
+++ b/plugin/auto_mkdir2.vim
@@ -1,8 +1,6 @@
 " auto_mkdir2.vim: Automatically create directories
 "
 " https://github.com/arp242/auto_mkdir2.vim
-"
-" See the bottom of this file for copyright & license information.
 
 
 scriptencoding utf-8
@@ -12,78 +10,16 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 
-if !exists('g:auto_mkdir2_allfiles')
-    let g:auto_mkdir2_allfiles = 1
+command! -bang -nargs=* -complete=dir MkdirP call auto_mkdir2#mkdir_p(<q-args>, <bang>get(g:, 'auto_mkdir2_confirm', 1))
+
+let s:x = get(g:, 'auto_mkdir2_autocmd', '*')
+if s:x isnot# ''
+	augroup auto_mkdir2
+		au!
+		exe printf("au BufWritePre %s call auto_mkdir2#autocmd()", s:x)
+	augroup end
 endif
-if !exists('g:auto_mkdir2_confirm')
-	let g:auto_mkdir2_confirm = 1
-endif
-
-
-"##########################################################
-" Commands
-command! -nargs=* -complete=dir MkdirP call s:mkdir_p(<q-args>, 1)
-command! -nargs=* -complete=dir MkdirPC call s:mkdir_p(<q-args>, v:cmdbang)
-
-if g:auto_mkdir2_allfiles == "1"
-    augroup auto_mkdir2
-        autocmd!
-        autocmd BufWritePre * call s:mkdir_p(expand("<amatch>:p:h"), v:cmdbang)
-    augroup end
-endif
-
-
-fun! s:mkdir_p(path, never_ask) abort
-	let l:dir = expand(a:path)
-	if l:dir is# ''
-		let l:dir = expand('%:p:h')
-	endif
-
-	if isdirectory(l:dir)
-		return
-	endif
-
-	if filereadable(l:dir)
-		echohl Error | echom printf("%s exists and isn't a directory", l:dir) | echohl None
-		return
-	endif
-
-	let l:response = 'y'
-	if !a:never_ask && get(g:, 'auto_mkdir2_confirm', 1)
-		echohl Question | echon printf('Create directory "%s" [y/N]? ', a:path) | echohl None
-
-		" TODO: When using :wq or ZZ I need to press <CR> here after y?
-		let response = nr2char(getchar())
-	endif
-
-    if l:response is? 'y'
-		call mkdir(iconv(l:dir, &encoding, &termencoding), 'p')
-    endif
-endfun
 
 
 let &cpo = s:save_cpo
 unlet s:save_cpo
-
-
-" The MIT License (MIT)
-"
-" Copyright © 2015-2017 Martin Tournoij
-"
-" Permission is hereby granted, free of charge, to any person obtaining a copy
-" of this software and associated documentation files (the "Software"), to
-" deal in the Software without restriction, including without limitation the
-" rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
-" sell copies of the Software, and to permit persons to whom the Software is
-" furnished to do so, subject to the following conditions:
-"
-" The above copyright notice and this permission notice shall be included in
-" all copies or substantial portions of the Software.
-"
-" The software is provided "as is", without warranty of any kind, express or
-" implied, including but not limited to the warranties of merchantability,
-" fitness for a particular purpose and noninfringement. In no event shall the
-" authors or copyright holders be liable for any claim, damages or other
-" liability, whether in an action of contract, tort or otherwise, arising
-" from, out of or in connection with the software or the use or other dealings
-" in the software.

--- a/plugin/auto_mkdir2.vim
+++ b/plugin/auto_mkdir2.vim
@@ -12,12 +12,25 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 
-command! -nargs=* -complete=dir MkdirP call s:mkdir_p(<q-args>, 1)
+if !exists('g:auto_mkdir2_allfiles')
+    let g:auto_mkdir2_allfiles = 1
+endif
+if !exists('g:auto_mkdir2_confirm')
+	let g:auto_mkdir2_confirm = 1
+endif
 
-augroup auto_mkdir2
-	autocmd!
-	autocmd BufWritePre * call s:mkdir_p(expand("<amatch>:p:h"), v:cmdbang)
-augroup end
+
+"##########################################################
+" Commands
+command! -nargs=* -complete=dir MkdirP call s:mkdir_p(<q-args>, 1)
+command! -nargs=* -complete=dir MkdirPC call s:mkdir_p(<q-args>, v:cmdbang)
+
+if g:auto_mkdir2_allfiles == "1"
+    augroup auto_mkdir2
+        autocmd!
+        autocmd BufWritePre * call s:mkdir_p(expand("<amatch>:p:h"), v:cmdbang)
+    augroup end
+endif
 
 
 fun! s:mkdir_p(path, never_ask) abort


### PR DESCRIPTION
With g:auto_mkdir2_autocmd you can control which files the autocmd
applies to, or disable it alltogether.

Move the functions to the autoload directory so you can call it from
scripts or your own autocmds.

Accept :MkdirP! to force creation of files regardless of
g:auto_mkdir2_confirm.